### PR TITLE
[proof-of-concept] Add translation_context to Control nodes

### DIFF
--- a/editor/plugins/packed_scene_translation_parser_plugin.cpp
+++ b/editor/plugins/packed_scene_translation_parser_plugin.cpp
@@ -71,8 +71,11 @@ Error PackedSceneEditorTranslationParserPlugin::parse_file(const String &p_path,
 		// Find the `auto_translate_mode` property.
 		bool auto_translating = true;
 		bool auto_translate_mode_found = false;
+		String translation_context = "";
+
 		for (int j = 0; j < state->get_node_property_count(i); j++) {
 			String property = state->get_node_property_name(i, j);
+
 			// If an old scene wasn't saved in the new version, the `auto_translate` property won't be converted into `auto_translate_mode`,
 			// so the deprecated property still needs to be checked as well.
 			// TODO: Remove the check for "auto_translate" once the property if fully removed.
@@ -110,6 +113,16 @@ Error PackedSceneEditorTranslationParserPlugin::parse_file(const String &p_path,
 				auto_translating = atr_owners[idx_last].second;
 			} else {
 				atr_owners.push_back(Pair(state->get_node_path(i), true));
+			}
+		}
+
+		// TODO: only loop once over the properties (between this and auto_translate_mode)
+		for (int j = 0; j < state->get_node_property_count(i); j++) {
+			String property = state->get_node_property_name(i, j);
+
+			if (property == "translation_context") {
+				translation_context = String(state->get_node_property_value(i, j));
+				break;
 			}
 		}
 
@@ -163,9 +176,10 @@ Error PackedSceneEditorTranslationParserPlugin::parse_file(const String &p_path,
 				}
 			} else if (property_value.get_type() == Variant::STRING) {
 				String str_value = String(property_value);
+				Variant _ctx_value = state->get_node_property_value(i, j);
 				// Prevent reading text containing only spaces.
 				if (!str_value.strip_edges().is_empty()) {
-					r_translations->push_back({ str_value });
+					r_translations->push_back({ str_value, translation_context });
 				}
 			}
 		}

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -3254,6 +3254,17 @@ String Control::get_tooltip_text() const {
 	return data.tooltip;
 }
 
+void Control::set_translation_context(const String &p_translation_context) {
+	ERR_MAIN_THREAD_GUARD;
+	data.translation_context = p_translation_context;
+	update_configuration_warnings();
+}
+
+String Control::get_translation_context() const {
+	ERR_READ_THREAD_GUARD_V(String());
+	return data.translation_context;
+}
+
 String Control::get_tooltip(const Point2 &p_pos) const {
 	ERR_READ_THREAD_GUARD_V(String());
 	String ret;
@@ -3596,6 +3607,9 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_tooltip_text"), &Control::get_tooltip_text);
 	ClassDB::bind_method(D_METHOD("get_tooltip", "at_position"), &Control::get_tooltip, DEFVAL(Point2()));
 
+	ClassDB::bind_method(D_METHOD("set_translation_context", "hint"), &Control::set_translation_context);
+	ClassDB::bind_method(D_METHOD("get_translation_context"), &Control::get_translation_context);
+
 	ClassDB::bind_method(D_METHOD("set_default_cursor_shape", "shape"), &Control::set_default_cursor_shape);
 	ClassDB::bind_method(D_METHOD("get_default_cursor_shape"), &Control::get_default_cursor_shape);
 	ClassDB::bind_method(D_METHOD("get_cursor_shape", "position"), &Control::get_cursor_shape, DEFVAL(Point2()));
@@ -3692,6 +3706,7 @@ void Control::_bind_methods() {
 
 	ADD_GROUP("Localization", "");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "localize_numeral_system"), "set_localize_numeral_system", "is_localizing_numeral_system");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "translation_context", PROPERTY_HINT_MULTILINE_TEXT), "set_translation_context", "get_translation_context");
 
 #ifndef DISABLE_DEPRECATED
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_translate", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_auto_translate", "is_auto_translating");
@@ -3861,4 +3876,11 @@ Control::~Control() {
 	data.theme_font_size_override.clear();
 	data.theme_color_override.clear();
 	data.theme_constant_override.clear();
+}
+
+String Control::_get_translation_context_with_override(const StringName &p_context) const {
+	if (p_context == "") {
+		return this->data.translation_context;
+	}
+	return p_context;
 }

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -267,6 +267,7 @@ private:
 
 		String tooltip;
 		AutoTranslateMode tooltip_auto_translate_mode = AUTO_TRANSLATE_MODE_INHERIT;
+		String translation_context;
 
 	} data;
 
@@ -328,6 +329,7 @@ private:
 	static int root_layout_direction;
 
 	String get_tooltip_text() const;
+	String get_translation_context() const;
 
 protected:
 	// Dynamic properties.
@@ -339,6 +341,9 @@ protected:
 
 	bool _property_can_revert(const StringName &p_name) const;
 	bool _property_get_revert(const StringName &p_name, Variant &r_property) const;
+
+	// Localization.
+	String _get_translation_context_with_override(const StringName &p_context) const override;
 
 	// Theming.
 
@@ -649,6 +654,7 @@ public:
 	// Extra properties.
 
 	void set_tooltip_text(const String &text);
+	void set_translation_context(const String &text);
 	virtual String get_tooltip(const Point2 &p_pos) const;
 	virtual Control *make_custom_tooltip(const String &p_text) const;
 

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -378,6 +378,9 @@ protected:
 
 	void _validate_property(PropertyInfo &p_property) const;
 
+	// Localization.
+	virtual String _get_translation_context_with_override(const StringName &p_context) const { return p_context; }
+
 protected:
 	virtual void input(const Ref<InputEvent> &p_event);
 	virtual void shortcut_input(const Ref<InputEvent> &p_key_event);
@@ -753,10 +756,10 @@ public:
 	virtual void set_translation_domain(const StringName &p_domain) override;
 	void set_translation_domain_inherited();
 
-	_FORCE_INLINE_ String atr(const String &p_message, const StringName &p_context = "") const { return can_auto_translate() ? tr(p_message, p_context) : p_message; }
+	_FORCE_INLINE_ String atr(const String &p_message, const StringName &p_context = "") const { return can_auto_translate() ? tr(p_message, _get_translation_context_with_override(p_context)) : p_message; }
 	_FORCE_INLINE_ String atr_n(const String &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context = "") const {
 		if (can_auto_translate()) {
-			return tr_n(p_message, p_message_plural, p_n, p_context);
+			return tr_n(p_message, p_message_plural, p_n, _get_translation_context_with_override(p_context));
 		}
 		return p_n == 1 ? p_message : String(p_message_plural);
 	}


### PR DESCRIPTION
Add a `translation_context` property to Control nodes.

Proof-of-concept for https://github.com/godotengine/godot-proposals/discussions/8061

I put together a proof-of-concept of how this could be implemented: https://github.com/jkirsteins/godot/pull/4

**A concrete example** 

Before the change I use the string _General_ in two places. A label in a settings screen (as in _General settings_) and on a card (as in "this is a card of an army General").

Before the change the generated `*.pot` file (the comment shows that it's used in two files):

```
#: card_template.tscn scenes/main_menu/settings_window.tscn
#: cards/card_data.tres
msgid "General"
msgstr "??? conflicting translation ???"
```

After the change you can specify the translation context on the label right in the Editor:

![Screenshot 2025-02-21 at 00 14 41](https://github.com/user-attachments/assets/b7dc61d8-5418-45e8-bc9b-b3f6f47cd5f7)

And the generated `*.pot/*.po` files now have two items for `General`, which can be translated separately:

```
#: card_template.tscn cards/card_data.tres
msgid "General"
msgstr "Le général"

#: scenes/main_menu/settings_window.tscn
msgctxt "settings_window"
msgid "General"
msgstr "Paramètres généraux"
```

